### PR TITLE
Put long author list at end

### DIFF
--- a/aastex61.cls
+++ b/aastex61.cls
@@ -6029,7 +6029,7 @@ needed. It will not do anything.^^J Please use
 \newcount\AuthorCollaborationLimit
 \let\AuthorCallLimit\AuthorCollaborationLimit
 %% no limit for default
-\AuthorCollaborationLimit=100
+\AuthorCollaborationLimit=10000
 \newcount\largestAffilNum
 
 \def\lookfornumbers#1#2#3#4#5#6#7#8#9{\def\one{#1}
@@ -6237,8 +6237,8 @@ needed. It will not do anything.^^J Please use
 \ifnumlines\nolinenumbers\fi
 \onecolumngrid
 \clearpage
-\AuthorCollaborationLimit=100
-\largestAffilNum=100
+\AuthorCollaborationLimit=10000
+\largestAffilNum=10000
 {\vskip6pt\vskip1sp\centerline{\large\bf All Authors and
 Affiliations\vrule depth 18pt width0pt}\nobreak
 \maketitle

--- a/lsst.tex
+++ b/lsst.tex
@@ -27,6 +27,7 @@
 
 \title{LSST: from Science Drivers to Reference Design and Anticipated Data Products}
 
+\AuthorCallLimit=2
 \include{authors}
 \include{abstract}
 
@@ -100,9 +101,8 @@ Version 3.0 (August 26, 2014): acknowledged the start of federal construction;
 updated system description and science examples, updated several figures; refreshed references;
 expanded author list.
 
-
-
 \bibliography{lsst}
+\allauthors
 
 \end{document}
 


### PR DESCRIPTION
AAS standard for large author lists is to put a short group at the start and the full list at the end. This requires a patch to AASTeX 6.1 to allow this to work with > 200 authors.